### PR TITLE
add .npmignore & update package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.*swp
+.env
+node_modules
+package-lock.json
+auxdata
+contracts
+tests/.testlog
+.vscode
+.testlog
+src
+tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermeznetwork/hermezjs",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Hermez SDK",
   "main": "dist/node/index.js",
   "module": "dist/browser/index.js",
@@ -16,8 +16,7 @@
     "build-browser": "cp -R src/ dist/browser",
     "prebuild": "rm -rf dist",
     "build": "npm run build-node && npm run build-browser",
-    "copy-prepublish": "cp package.json README.md README_sandbox.md hermez.js.LICENSE.txt dist",
-    "build-publish": "npm run build && npm run copy-prepublish && npm publish dist",
+    "build-publish": "npm run build && npm publish",
     "test": "./tests/launch-test.sh",
     "lint": "standard",
     "lint:fix": "standard --fix"


### PR DESCRIPTION
This PR sets the `.npmignore` file in order to select which files are uploaded to npm.
Note the following:
- `dist` folder is uploaded to npm and `src` folder is uploaded to github
- `tests` folder are not loaded in npm