### PR TITLE
implement transferToBJJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ To deploy a local setup of a Hermez Coordinator with the Hermez smart contracts 
 ```sh
 git clone https://github.com/hermeznetwork/integration-testing.git
 cd integration-testing
-make build
-make start
+make start BUILD=sandbox-geth DEV_PERIOD=3 MODE=coord
+```
+
+To stop environment:
+```
+make stop
 ```
 
 **NOTE** To run all tests, type:

--- a/src/addresses.js
+++ b/src/addresses.js
@@ -1,7 +1,7 @@
 import { utils as utilsScalar, Scalar } from 'ffjavascript'
 import base64url from 'base64url'
 
-import { padZeros } from './utils.js'
+import { padZeros, extract } from './utils.js'
 
 const hermezPrefix = 'hez:'
 const hezEthereumAddressPattern = new RegExp('^hez:0x[a-fA-F0-9]{40}$')
@@ -104,6 +104,35 @@ function hexToBase64BJJ (bjjCompressedHex) {
   return `hez:${base64url.encode(finalBuffBjj)}`
 }
 
+/**
+ * Gets the Babyjubjub hexadecimal from its base64 representation
+ * @param {String} base64BJJ
+ * @returns {String} babyjubjub address in hex string
+ */
+function base64ToHexBJJ (base64BJJ) {
+  if (base64BJJ.includes('hez:')) {
+    base64BJJ = base64BJJ.replace('hez:', '')
+  }
+
+  const bjjSwapHex = base64url.decode(base64BJJ, 'hex')
+  const bjjSwapBuff = Buffer.from(bjjSwapHex, 'hex').slice(0, 32)
+
+  return padZeros(utilsScalar.leBuff2int(bjjSwapBuff).toString(16), 64)
+}
+
+/**
+ * Get Ay and Sign from Bjj compressed
+ * @param {String} fromBjjCompressed Bjj compressed encoded as hexadecimal string
+ * @return {Object} Ay represented as hexadecimal string, Sign represented as BigInt
+ */
+function getAySignFromBJJ (fromBjjCompressed) {
+  const scalarFromBjjCompressed = Scalar.fromString(fromBjjCompressed, 16)
+  const ay = extract(scalarFromBjjCompressed, 0, 254).toString(16)
+  const sign = Number(extract(scalarFromBjjCompressed, 255, 1))
+
+  return { ay, sign }
+}
+
 export {
   getHermezAddress,
   getEthereumAddress,
@@ -111,5 +140,7 @@ export {
   isHermezBjjAddress,
   isHermezAccountIndex,
   getAccountIndex,
-  hexToBase64BJJ
+  hexToBase64BJJ,
+  base64ToHexBJJ,
+  getAySignFromBJJ
 }

--- a/src/addresses.js
+++ b/src/addresses.js
@@ -78,7 +78,7 @@ function isHermezAccountIndex (test) {
 
 /**
  * Get API Bjj compressed data format
- * @param {String} bjjCompressedHex Bjj compressed address encoded as hex string
+ * @param {String} bjjCompressedHex - Bjj compressed address encoded as hex string
  * @returns {String} API adapted bjj compressed address
  */
 function hexToBase64BJJ (bjjCompressedHex) {
@@ -122,7 +122,7 @@ function base64ToHexBJJ (base64BJJ) {
 
 /**
  * Get Ay and Sign from Bjj compressed
- * @param {String} fromBjjCompressed Bjj compressed encoded as hexadecimal string
+ * @param {String} fromBjjCompressed - Bjj compressed encoded as hexadecimal string
  * @return {Object} Ay represented as hexadecimal string, Sign represented as BigInt
  */
 function getAySignFromBJJ (fromBjjCompressed) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,8 @@ const CONTRACT_ADDRESSES = {
   [ContractNames.WithdrawalDelayer]: '0x8EEaea23686c319133a7cC110b840d1591d9AeE0'
 }
 
+const INTERNAL_ACCOUNT_ETH_ADDR = 'hez:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+
 const STORAGE_VERSION_KEY = 'hermezStorageVersion'
 
 const STORAGE_VERSION = 1
@@ -50,5 +52,6 @@ export {
   ContractNames,
   CONTRACT_ADDRESSES,
   STORAGE_VERSION_KEY,
-  STORAGE_VERSION
+  STORAGE_VERSION,
+  INTERNAL_ACCOUNT_ETH_ADDR
 }

--- a/src/enums.js
+++ b/src/enums.js
@@ -3,6 +3,7 @@ const TxType = {
   CreateAccountDeposit: 'CreateAccountDeposit',
   Transfer: 'Transfer',
   TransferToEthAddr: 'TransferToEthAddr',
+  TransferToBJJ: 'TransferToBJJ',
   Withdraw: 'Withdrawn',
   Exit: 'Exit',
   ForceExit: 'ForceExit'

--- a/src/hermez-wallet.js
+++ b/src/hermez-wallet.js
@@ -2,10 +2,9 @@ import circomlib from 'circomlib'
 import jsSha3 from 'js-sha3'
 import { utils } from 'ffjavascript'
 import { ethers } from 'ethers'
-import crypto from 'crypto'
 
 import { buildTransactionHashMessage } from './tx-utils.js'
-import { hexToBuffer } from './utils.js'
+import { hexToBuffer, getRandomBytes } from './utils.js'
 import { getProvider } from './providers.js'
 import { getHermezAddress, isHermezEthereumAddress, hexToBase64BJJ } from './addresses.js'
 import { METAMASK_MESSAGE, CREATE_ACCOUNT_AUTH_MESSAGE, EIP_712_VERSION, EIP_712_PROVIDER, CONTRACT_ADDRESSES, ContractNames, INTERNAL_ACCOUNT_ETH_ADDR } from './constants.js'
@@ -113,15 +112,15 @@ async function createWalletFromEtherAccount (providerUrl, signerData) {
 }
 
 /**
- * Creates a HermezWallet from babyjubjub private key
+ * Creates a HermezWallet from Babyjubjub private key
  * This creates a wallet for an internal account
- * Internal account has babyjubjub key and ethereum account 0xFFFF...FFFF
- * Random wallet is created if no private key is submitted
- * @param {Buffer} privateKey - Signer data used to build a Signer to create the walet
+ * An internal account has a Babyjubjub key and Ethereum account 0xFFFF...FFFF
+ * Random wallet is created if no private key is provided
+ * @param {Buffer} privateKey - 32 bytes buffer
  * @returns {Object} Contains the `hermezWallet` as a HermezWallet instance and the `hermezEthereumAddress`
  */
 async function createWalletFromBjjPvtKey (privateKey) {
-  const privateBjjKey = privateKey || crypto.randomBytes(32)
+  const privateBjjKey = privateKey || Buffer.from(getRandomBytes(32))
   const hermezWallet = new HermezWallet(privateBjjKey, INTERNAL_ACCOUNT_ETH_ADDR)
 
   return { hermezWallet, hermezEthereumAddress: INTERNAL_ACCOUNT_ETH_ADDR }

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,12 +49,27 @@ function padZeros (string, length) {
  * Mask and shift a Scalar
  * @param {Scalar} num - Input number
  * @param {Number} origin - Initial bit
- * @param {Number} len - Bit lenght of the mask
- * @returns {Scalar} Extracted Scalar
+ * @param {Number} len - Bit length of the mask
+ * @returns {Scalar} Scalar
  */
 function extract (num, origin, len) {
   const mask = Scalar.sub(Scalar.shl(1, len), 1)
   return Scalar.band(Scalar.shr(num, origin), mask)
+}
+
+/**
+ * Generates random bytes
+ * @param {Number} numBytes - number of bytes to generate
+ * @returns {Uint8Array} Array of random 'numBytes'
+ */
+function getRandomBytes (numBytes) {
+  const array = new Uint8Array(numBytes)
+  if (typeof window !== 'undefined' && typeof window.crypto !== 'undefined') {
+    window.crypto.getRandomValues(array)
+  } else {
+    require('crypto').randomFillSync(array)
+  }
+  return array
 }
 
 export {
@@ -63,5 +78,6 @@ export {
   getTokenAmountString,
   getTokenAmountBigInt,
   padZeros,
-  extract
+  extract,
+  getRandomBytes
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+import { Scalar } from 'ffjavascript'
 
 /**
  * Converts a buffer to a hexadecimal representation
@@ -44,10 +45,23 @@ function padZeros (string, length) {
   return string
 }
 
+/**
+ * Mask and shift a Scalar
+ * @param {Scalar} num - Input number
+ * @param {Number} origin - Initial bit
+ * @param {Number} len - Bit lenght of the mask
+ * @returns {Scalar} Extracted Scalar
+ */
+function extract (num, origin, len) {
+  const mask = Scalar.sub(Scalar.shl(1, len), 1)
+  return Scalar.band(Scalar.shr(num, origin), mask)
+}
+
 export {
   bufToHex,
   hexToBuffer,
   getTokenAmountString,
   getTokenAmountBigInt,
-  padZeros
+  padZeros,
+  extract
 }

--- a/tests/addresses.test.js
+++ b/tests/addresses.test.js
@@ -4,6 +4,8 @@ const ethereumAddress = '0x4294cE558F2Eb6ca4C3191AeD502cF0c625AE995'
 const hermezEthereumAddress = 'hez:0x4294cE558F2Eb6ca4C3191AeD502cF0c625AE995'
 const hermezHexBjjAddress = '8128bb403a7e7641b1e34f00f9b5922b27a8583a163609e39e96bde63f422008'
 const hermezBjjAddress = 'hez:CCBCP-a9lp7jCTYWOlioJyuStfkAT-OxQXZ-OkC7KIF6'
+const expectedAy = '128bb403a7e7641b1e34f00f9b5922b27a8583a163609e39e96bde63f422008'
+const expectedSign = 1
 const hermezAccountIndex = 'hez:TKN:256'
 const accountIndex = 256
 
@@ -36,4 +38,14 @@ test('#isHermezAccountIndex', () => {
 
 test('#hexToBase64BJJ', () => {
   expect(addresses.hexToBase64BJJ(hermezHexBjjAddress)).toBe(hermezBjjAddress)
+})
+
+test('#base64ToHexBJJ', () => {
+  expect(addresses.base64ToHexBJJ(hermezBjjAddress)).toBe(hermezHexBjjAddress)
+})
+
+test('#getAySignFromBJJ', () => {
+  const { ay, sign } = addresses.getAySignFromBJJ(hermezHexBjjAddress)
+  expect(ay).toBe(expectedAy)
+  expect(sign).toBe(expectedSign)
 })

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -243,7 +243,10 @@ describe.skip('#getBids', () => {
 
 test('#postCreateAccountAuthorization', async () => {
   const { hermezWallet } = await createWalletFromEtherAccount('http://localhost:8545')
-  const signature = await hermezWallet.signCreateAccountAuthorization('http://localhost:8545')
+  const privateKeyEth = '0x0000000000000000000000000000000000000000000000000000000000000001'
+  const signer = { type: 'WALLET', privateKey: privateKeyEth }
+
+  const signature = await hermezWallet.signCreateAccountAuthorization('http://localhost:8545', signer)
   const res = await CoordinatorAPI.postCreateAccountAuthorization(
     hermezWallet.hermezEthereumAddress,
     hermezWallet.publicKeyBase64,

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -4,30 +4,6 @@ import * as CoordinatorAPI from '../../src/api.js'
 import { getL1UserTxId } from '../../src/tx-utils.js'
 
 /**
- * Wait a specific number of batches to be forged
- * @param {Number} nBatches
- */
-export async function waitNBatches (nBatches) {
-  let lastBatch = (await CoordinatorAPI.getState()).network.lastBatch
-  while (true) {
-    let currentBatch = (await CoordinatorAPI.getState()).network.lastBatch
-    if (lastBatch !== null &&
-        currentBatch !== null &&
-        currentBatch.batchNum - lastBatch.batchNum >= nBatches) {
-      return currentBatch.batchNum
-    }
-    if (lastBatch === null) {
-      lastBatch = (await CoordinatorAPI.getState()).network.lastBatch
-      currentBatch = lastBatch
-    }
-    if (currentBatch === null) {
-      currentBatch = (await CoordinatorAPI.getState()).network.lastBatch
-    }
-    await sleep(2000)
-  }
-}
-
-/**
  * Wait timeout
  * @param {Number} timeout
  */
@@ -86,7 +62,7 @@ export async function assertTxForged (txId, timeoutLoop) {
 
 /**
  * Generic balances asserts
- * @param {Array[Object]} accounts array of account to check its balances
+ * @param {Array[Object]} accounts array of account to check their balances
  * @param {Object} token token object
  */
 export async function assertBalances (accounts, token) {

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -1,6 +1,7 @@
 import testHelpers from '@openzeppelin/test-helpers'
 
 import * as CoordinatorAPI from '../../src/api.js'
+import { getL1UserTxId } from '../../src/tx-utils.js'
 
 /**
  * Wait a specific number of batches to be forged
@@ -40,4 +41,86 @@ async function sleep (timeout) {
  */
 export async function advanceTime () {
   await testHelpers.time.increase(60 * 61)
+}
+
+/**
+ * Get L1 transaction identifier by inspecting its ethereum receipt
+ * @param {Object} l1Receipt ethereum receipt
+ * @returns {String} L1 transaction identifier
+ */
+export function getL1TxIdFromReceipt (l1Receipt) {
+  const eventL1UserTx = l1Receipt.events.filter(event => event.event === 'L1UserTxEvent')
+  const eventArgs = eventL1UserTx[0].args
+  return getL1UserTxId(eventArgs[0], eventArgs[1])
+}
+
+/**
+ * Check that any transaction is forged by its txID
+ * @param {Object} txId - transaction Id
+ * @param {Object} timeoutLoop - timeout loop among checks
+ */
+export async function assertTxForged (txId, timeoutLoop) {
+  let forged = false
+  let counter = 0
+
+  while (!forged && counter < 20) {
+    try {
+      const txInfo = await CoordinatorAPI.getHistoryTransaction(txId)
+      if (txInfo.batchNum != null) {
+        forged = true
+        continue
+      } else {
+        counter += 1
+      }
+    } catch (error) {
+      counter += 1
+    }
+
+    await sleep(timeoutLoop || 10000)
+    counter += 1
+  }
+  if (!forged) {
+    throw new Error(`TxId ${txId} has not been forged`)
+  }
+}
+
+/**
+ * Generic balances asserts
+ * @param {Array[Object]} accounts array of account to check its balances
+ * @param {Object} token token object
+ */
+export async function assertBalances (accounts, token) {
+  for (let i = 0; i < accounts.length; i++) {
+    const hezAddress = accounts[i].hermezWallet.hermezEthereumAddress
+    const index = accounts[i].index
+    const expectedBalance = accounts[i].expectedBalance
+
+    if (expectedBalance !== null) {
+      const accountInfo = await CoordinatorAPI.getAccounts(hezAddress, [token.id])
+
+      if (accountInfo.accounts[0].balance.toString() !== expectedBalance.toString()) {
+        let logError = `Account ${index}\n`
+        logError += `   balance is ${accountInfo.accounts[0].balance.toString()}\n`
+        logError += `   expected balance is ${expectedBalance.toString()}\n`
+        throw new Error(logError)
+      }
+    }
+  }
+}
+
+/**
+ * Print balances for each account
+ * @param {Array[Object]} accounts array of account to check its balances
+ * @param {Object} token token object
+ */
+export async function printBalances (accounts, token) {
+  for (let i = 0; i < accounts.length; i++) {
+    const hezAddress = accounts[i].hermezWallet.hermezEthereumAddress
+    const index = accounts[i].index
+
+    const accountInfo = await CoordinatorAPI.getAccounts(hezAddress, [token.id])
+    console.log('accountInfo: ', accountInfo)
+    const balance = accountInfo.accounts[0].balance.toString()
+    console.log(`Account ${index}: ${balance}`)
+  }
 }

--- a/tests/hermez-wallet.test.js
+++ b/tests/hermez-wallet.test.js
@@ -1,8 +1,9 @@
 import circomlib from 'circomlib'
 import { utils, Scalar } from 'ffjavascript'
 
-import { HermezWallet, createWalletFromEtherAccount } from '../src/hermez-wallet.js'
+import { HermezWallet, createWalletFromEtherAccount, createWalletFromBjjPvtKey } from '../src/hermez-wallet.js'
 import { isHermezEthereumAddress } from '../src/addresses.js'
+import { INTERNAL_ACCOUNT_ETH_ADDR } from '../src/constants'
 
 describe('HermezWallet', () => {
   const hermezEthereumAddress = 'hez:0x4294cE558F2Eb6ca4C3191AeD502cF0c625AE995'
@@ -92,13 +93,33 @@ describe('HermezWallet', () => {
   })
 
   test('#signCreateAccountAuthorization', async () => {
-    const signature = await wallet.signCreateAccountAuthorization('http://localhost:8545')
-    expect(signature).toBe('0x688389b045ca0940c2dde5e02a01d0aedf652dd8f7c13eaa7218854c60e9b680381befe0a65ed83bca9932c49a6ebe30ae5d65f9a3d9d40254b7ea9e2b8a11901c')
-  })
-})
+    const expectedSignature = '0x05800968d7d6ffa8368ac363f62ae00213479591e84b7ed07ccbfd40de84cb0d0bb7130748f4d3150d77f1848e1372b84113ba3955a9cefe1bb26b773986d4191b'
+    const privateKeyEth = '0x0000000000000000000000000000000000000000000000000000000000000001'
 
-test('#createWalletFromEtherAccount', async () => {
-  const { hermezWallet, hermezEthereumAddress } = await createWalletFromEtherAccount('http://localhost:8545')
-  expect(hermezWallet).toBeInstanceOf(HermezWallet)
-  expect(isHermezEthereumAddress(hermezEthereumAddress)).toBe(true)
+    const signer = { type: 'WALLET', privateKey: privateKeyEth }
+    const hermezWallet = (await createWalletFromEtherAccount('http://localhost:8545', signer)).hermezWallet
+
+    const signature = await hermezWallet.signCreateAccountAuthorization('http://localhost:8545', signer)
+    expect(signature).toEqual(expectedSignature)
+  })
+
+  test('#createWalletFromBjjPvtKey', async () => {
+    const { hermezWallet, hermezEthereumAddress } = await createWalletFromBjjPvtKey(privateKey)
+    expect(hermezWallet).toBeInstanceOf(HermezWallet)
+    expect(isHermezEthereumAddress(hermezEthereumAddress)).toBe(true)
+    expect(hermezEthereumAddress).toBe(INTERNAL_ACCOUNT_ETH_ADDR)
+  })
+
+  test('#createWalletFromBjjPvtKey random private', async () => {
+    const { hermezWallet, hermezEthereumAddress } = await createWalletFromBjjPvtKey()
+    expect(hermezWallet).toBeInstanceOf(HermezWallet)
+    expect(isHermezEthereumAddress(hermezEthereumAddress)).toBe(true)
+    expect(hermezEthereumAddress).toBe(INTERNAL_ACCOUNT_ETH_ADDR)
+  })
+
+  test('#createWalletFromEtherAccount', async () => {
+    const { hermezWallet, hermezEthereumAddress } = await createWalletFromEtherAccount('http://localhost:8545')
+    expect(hermezWallet).toBeInstanceOf(HermezWallet)
+    expect(isHermezEthereumAddress(hermezEthereumAddress)).toBe(true)
+  })
 })

--- a/tests/tx-utils.test.js
+++ b/tests/tx-utils.test.js
@@ -137,6 +137,13 @@ describe('#getTransactionType', () => {
     }
     expect(TxUtils.getTransactionType(exitTx)).toBe('Exit')
   })
+
+  test('Returns TransferToBJJ', () => {
+    const transferToBJJ = {
+      to: 'hez:CCBCP-a9lp7jCTYWOlioJyuStfkAT-OxQXZ-OkC7KIF6'
+    }
+    expect(TxUtils.getTransactionType(transferToBJJ)).toBe('TransferToBJJ')
+  })
 })
 
 describe('#getNonce', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -33,6 +33,7 @@ test('#getTokenAmountString', () => {
     expect(utils.getTokenAmountString(testString, i)).toBe(testVector[i])
   }
 })
+
 test('#getTokenAmountBigInt', () => {
   const testString = '1234567'
   const testVector = [
@@ -51,4 +52,12 @@ test('#getTokenAmountBigInt', () => {
   for (var i = 0; i < testVector.length; i++) {
     expect(utils.getTokenAmountBigInt(testString, i).toString()).toBe(testVector[i])
   }
+})
+
+test('#getRandomBytes', () => {
+  const pvtBytes = 32
+  const pvtKeyRandom = utils.getRandomBytes(pvtBytes)
+  console.log(pvtKeyRandom)
+  expect(pvtKeyRandom.length).toBe(32)
+  expect(pvtKeyRandom).not.toBe(undefined)
 })


### PR DESCRIPTION
This PR adds the following:
- ability to create wallets for internal accounts
- implements `transferToBJJ` L2 transaction type
- fixes `signCreateAccountAuthorization` test
- add full integration test for `tx.test.js`