### PR TITLE
support maxBatchNum parameter in L2 transaction

### DIFF
--- a/src/tx-utils.js
+++ b/src/tx-utils.js
@@ -356,6 +356,7 @@ function buildTransactionHashMessage (encodedTransaction) {
  * @param {HermezCompressedAmount} transaction.amount - The amount being sent as a HermezCompressedAmount
  * @param {Number} transaction.fee - The amount of tokens to be sent as a fee to the Coordinator
  * @param {Number} transaction.nonce - The current nonce of the sender's token account (optional)
+ * @param {Number} transaction.maxNumBatch - maximum allowed batch number when the transaction can be processed (optional)
  * @param {String} bjj - The compressed BabyJubJub in hexadecimal format of the transaction sender
  * @param {Object} token - The token information object as returned from the Coordinator.
  * @return {Object} - Contains `transaction` and `encodedTransaction`. `transaction` is the object almost ready to be sent to the Coordinator. `encodedTransaction` is needed to sign the `transaction`
@@ -393,7 +394,8 @@ async function generateL2Transaction (tx, bjj, token) {
     requestTokenId: null,
     requestAmount: null,
     requestFee: null,
-    requestNonce: null
+    requestNonce: null,
+    maxNumBatch: typeof tx.maxNumBatch === 'undefined' ? 0 : tx.maxNumBatch
   }
 
   const encodedTransaction = await encodeTransaction(transaction)

--- a/src/tx.js
+++ b/src/tx.js
@@ -382,6 +382,7 @@ async function sendL2Transaction (transaction, bJJ, nextForgers, addToTxPool) {
  * @param {HermezCompressedAmount} transaction.amount - The amount being sent in the compressed format
  * @param {Number} transaction.fee - The amount of tokens to be sent as a fee to the Coordinator
  * @param {Number} transaction.nonce - The current nonce of the sender's token account
+ * @param {Number} transaction.maxNumBatch - maximum allowed batch number when the transaction can be processed (optional)
  * @param {Object} wallet - Transaction sender Hermez Wallet
  * @param {Object} token - The token information object as returned from the Coordinator.
  * @param {Array} nextForgers - An array of URLs of the next forgers to send the L2 tx to.

--- a/tests/unit/tx-utils.test.js
+++ b/tests/unit/tx-utils.test.js
@@ -23,7 +23,8 @@ const transferTransaction = {
   requestTokenId: null,
   requestAmount: null,
   requestFee: null,
-  requestNonce: null
+  requestNonce: null,
+  maxNumBatch: 0
 }
 
 const transferTransactionEncoded = Object.assign({}, transferTransaction, {
@@ -49,7 +50,8 @@ const exitTransaction = {
   requestTokenId: null,
   requestAmount: null,
   requestFee: null,
-  requestNonce: null
+  requestNonce: null,
+  maxNumBatch: 0
 }
 
 const exitTransactionEncoded = Object.assign({}, exitTransaction, {
@@ -443,6 +445,25 @@ describe('#generateL2Transaction', () => {
     encodedTransaction.type = 'Exit'
     expect(transaction).toEqual(exitTransaction)
     expect(encodedTransaction).toEqual(exitTransactionEncoded)
+  })
+
+  test('Check maxNumBatch', async () => {
+    // expected transaction with maxNumBatch
+    const expectedTx = Object.assign({}, transferTransaction, { maxNumBatch: 3 })
+    // transaction with maxNumBatch
+    const tx = Object.assign({}, transferTx, { maxNumBatch: 3 })
+
+    const txEncoded = Object.assign({}, transferTransactionEncoded, {
+      maxNumBatch: 3,
+      chainId: 1337,
+      fromAccountIndex: 4444,
+      toAccountIndex: 1234
+    })
+
+    const { transaction, encodedTransaction } = await TxUtils.generateL2Transaction(tx, bjj, token)
+
+    expect(transaction).toEqual(expectedTx)
+    expect(encodedTransaction).toEqual(txEncoded)
   })
 })
 


### PR DESCRIPTION
This PR does the following:
- allow user to add `maxNumBatch` parameter to be signed in a L2 transaction
- parameter is optional. Default to `maxNumBatch = 0`
- add unit tests