### PR TITLE
event on release candidate

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,9 @@
 name: Integration testing
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    tags:
+      - '*rc*'
 
 jobs:
   trigger-integration:


### PR DESCRIPTION
This PR changes when the `integration-testing` is updated.
It will trigger an event every time a new release candidate is done following the matching patter `*rc*`