### PR TITLE
Add support for multi-coordinator state api calls

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -245,8 +245,8 @@ async function getToken (tokenId, axiosConfig = {}) {
  * GET request to the /state endpoint.
  * @returns {Object} Response data with the current state of the coordinator
  */
-async function getState (axiosConfig = {}) {
-  return extractJSON(axios.get(`${baseApiUrl}/${API_VERSION}/state`, axiosConfig))
+async function getState (axiosConfig = {}, apiUrl = baseApiUrl) {
+  return extractJSON(axios.get(`${apiUrl}/${API_VERSION}/state`, axiosConfig))
 }
 
 /**

--- a/src/api.js
+++ b/src/api.js
@@ -243,6 +243,7 @@ async function getToken (tokenId, axiosConfig = {}) {
 
 /**
  * GET request to the /state endpoint.
+ * @param {String} apiUrl - API URL of the coordinator to request the state from
  * @returns {Object} Response data with the current state of the coordinator
  */
 async function getState (axiosConfig = {}, apiUrl = baseApiUrl) {


### PR DESCRIPTION
### What does this PR does?

This PR adds support to query the state API of any coordinator in the network.

### How to test?

1. Call the `getCoordinatorState` API function with a URL different than the boot cordinator one.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [x] Update documentation (if needed)
