### PR TITLE
make sure comparison with INTERNAL_ACCOUNT_ETH_ADDR is correct

### DIFF
--- a/src/tx-utils.js
+++ b/src/tx-utils.js
@@ -355,7 +355,7 @@ async function generateL2Transaction (tx, bjj, token) {
   if (type === TxType.TransferToEthAddr) {
     toHezEthereumAddress = tx.to
   } else if (type === TxType.TransferToBJJ) {
-    toHezEthereumAddress = tx.toAuxEthAddr || INTERNAL_ACCOUNT_ETH_ADDR
+    toHezEthereumAddress = tx.toAuxEthAddr.toLowerCase() || INTERNAL_ACCOUNT_ETH_ADDR.toLowerCase()
   } else {
     toHezEthereumAddress = null
   }


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #524 .

### What does this PR does?

When comparing to `const INTERNAL_ACCOUNT_ETH_ADDR = 'hez:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'` convert both compared value and the constant to lowercase to ensure a possible match (due to possibility of random combination or upper and lower case of letter F in the address).

### How to test?

Try sending transfer to `hez:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` or `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF`or any combination of lower/upper case of letter F.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [ ] Update documentation (if needed)
