### PR TITLE
Fix links to withdrawal wasm and zkey static files

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -55,9 +55,9 @@ const MAX_NLEVELS = 48
 
 const WITHDRAWAL_CIRCUIT_NLEVELS = 32
 
-const WITHDRAWAL_WASM_URL = 'https://github.com/hermeznetwork/hermezjs/blob/main/withdraw-circuit-files/withdraw.wasm'
+const WITHDRAWAL_WASM_URL = 'http://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw.wasm'
 
-const WITHDRAWAL_ZKEY_URL = 'https://github.com/hermeznetwork/hermezjs/blob/main/withdraw-circuit-files/withdraw_hez4_final.zkey'
+const WITHDRAWAL_ZKEY_URL = 'http://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw_hez4_final.zkey'
 
 const ETHER_ADDRESS = '0x0000000000000000000000000000000000000000'
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,9 +55,9 @@ const MAX_NLEVELS = 48
 
 const WITHDRAWAL_CIRCUIT_NLEVELS = 32
 
-const WITHDRAWAL_WASM_URL = 'http://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw.wasm'
+const WITHDRAWAL_WASM_URL = 'https://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw.wasm'
 
-const WITHDRAWAL_ZKEY_URL = 'http://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw_hez4_final.zkey'
+const WITHDRAWAL_ZKEY_URL = 'https://raw.githubusercontent.com/hermeznetwork/hermezjs/main/withdraw-circuit-files/withdraw_hez4_final.zkey'
 
 const ETHER_ADDRESS = '0x0000000000000000000000000000000000000000'
 


### PR DESCRIPTION
### What does this PR does?

Fixes the links to the static files `withdraw.wasm` and `withdraw_hez4_final.zkey`.

### How to test?

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [x] Update documentation (if needed)
