### PR TITLE
Fix #206: incorrect /tokens url

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -238,8 +238,8 @@ async function getExit (batchNum, accountIndex, axiosConfig = {}) {
  */
 async function getTokens (tokenIds, tokenSymbols, fromItem, order = PaginationOrder.ASC, limit = DEFAULT_PAGE_SIZE, axiosConfig = {}) {
   const params = {
-    ...(tokenIds ? { ids: tokenIds.join(',') } : {}),
-    ...(tokenSymbols ? { symbols: tokenSymbols.join(',') } : {}),
+    ...(tokenIds ? { ids: tokenIds.join('|') } : {}),
+    ...(tokenSymbols ? { symbols: tokenSymbols.join('|') } : {}),
     ..._getPageData(fromItem, order, limit)
   }
 


### PR DESCRIPTION
Closes #206.

### What does this PR does?

fixes url for /tokens action for cases when multiple tokenIds or tokenSymbols passed
