### PR TITLE
Avoid exitInfo merkleProof siblings mutation

### DIFF
--- a/src/withdraw-utils.js
+++ b/src/withdraw-utils.js
@@ -21,7 +21,7 @@ async function buildZkInputWithdraw (exitInfo) {
   zkInputWithdrawal.idx = Scalar.e(getAccountIndex(exitInfo.accountIndex))
   zkInputWithdrawal.sign = Scalar.e(sign)
   zkInputWithdrawal.ay = Scalar.fromString(ay, 16)
-  const siblings = exitInfo.merkleProof.siblings
+  const siblings = [...exitInfo.merkleProof.siblings]
   while (siblings.length < (WITHDRAWAL_CIRCUIT_NLEVELS + 1)) siblings.push(Scalar.e(0))
   zkInputWithdrawal.siblingsState = siblings
 


### PR DESCRIPTION
### What does this PR does?

This PR avoids mutating the `siblings` obtained from the `exit` in the function `buildZkInputWithdraw`. This mutation is not required and was causing problems in some clients.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [x] Respect code style and lint
- [x] Update documentation (if needed)
